### PR TITLE
Handling ConvTranspose2d layers properly

### DIFF
--- a/bn_fusion.py
+++ b/bn_fusion.py
@@ -14,10 +14,7 @@ def fuse_bn_sequential(block):
     stack = []
     for m in block.children():
         if isinstance(m, nn.BatchNorm2d):
-            if isinstance(stack[-1], nn.Conv2d) or isinstance(
-                stack[-1], nn.ConvTranspose2d
-            ):
-                # Extract params of BatchNorm and Convolution layers
+            if isinstance(stack[-1], nn.Conv2d) or isinstance(stack[-1], nn.ConvTranspose2d):
                 bn_st_dict = m.state_dict()
                 conv_st_dict = stack[-1].state_dict()
 
@@ -34,7 +31,6 @@ def fuse_bn_sequential(block):
 
                 # Conv params
                 W = conv_st_dict["weight"]
-
                 if isinstance(stack[-1], nn.ConvTranspose2d):
                     W = W.transpose(0, 1)
 

--- a/bn_fusion.py
+++ b/bn_fusion.py
@@ -20,22 +20,22 @@ def fuse_bn_sequential(block):
 
                 # BatchNorm params
                 eps = m.eps
-                mu = bn_st_dict["running_mean"]
-                var = bn_st_dict["running_var"]
-                gamma = bn_st_dict["weight"]
+                mu = bn_st_dict['running_mean']
+                var = bn_st_dict['running_var']
+                gamma = bn_st_dict['weight']
 
-                if "bias" in bn_st_dict:
-                    beta = bn_st_dict["bias"]
+                if 'bias' in bn_st_dict:
+                    beta = bn_st_dict['bias']
                 else:
                     beta = torch.zeros(gamma.size(0)).float().to(gamma.device)
 
                 # Conv params
-                W = conv_st_dict["weight"]
+                W = conv_st_dict['weight']
                 if isinstance(stack[-1], nn.ConvTranspose2d):
                     W = W.transpose(0, 1)
 
-                if "bias" in conv_st_dict:
-                    bias = conv_st_dict["bias"]
+                if 'bias' in conv_st_dict:
+                    bias = conv_st_dict['bias']
                 else:
                     bias = torch.zeros(W.size(0)).float().to(gamma.device)
 
@@ -56,6 +56,7 @@ def fuse_bn_sequential(block):
                     stack[-1].bias = torch.nn.Parameter(bias)
                 else:
                     stack[-1].bias.data.copy_(bias)
+
         else:
             stack.append(m)
 

--- a/bn_fusion.py
+++ b/bn_fusion.py
@@ -14,43 +14,52 @@ def fuse_bn_sequential(block):
     stack = []
     for m in block.children():
         if isinstance(m, nn.BatchNorm2d):
-            if isinstance(stack[-1], nn.Conv2d):
+            if isinstance(stack[-1], nn.Conv2d) or isinstance(
+                stack[-1], nn.ConvTranspose2d
+            ):
+                # Extract params of BatchNorm and Convolution layers
                 bn_st_dict = m.state_dict()
                 conv_st_dict = stack[-1].state_dict()
 
                 # BatchNorm params
                 eps = m.eps
-                mu = bn_st_dict['running_mean']
-                var = bn_st_dict['running_var']
-                gamma = bn_st_dict['weight']
+                mu = bn_st_dict["running_mean"]
+                var = bn_st_dict["running_var"]
+                gamma = bn_st_dict["weight"]
 
-                if 'bias' in bn_st_dict:
-                    beta = bn_st_dict['bias']
+                if "bias" in bn_st_dict:
+                    beta = bn_st_dict["bias"]
                 else:
                     beta = torch.zeros(gamma.size(0)).float().to(gamma.device)
 
                 # Conv params
-                W = conv_st_dict['weight']
-                if 'bias' in conv_st_dict:
-                    bias = conv_st_dict['bias']
+                W = conv_st_dict["weight"]
+
+                if isinstance(stack[-1], nn.ConvTranspose2d):
+                    W = W.transpose(0, 1)
+
+                if "bias" in conv_st_dict:
+                    bias = conv_st_dict["bias"]
                 else:
                     bias = torch.zeros(W.size(0)).float().to(gamma.device)
 
                 denom = torch.sqrt(var + eps)
-                b = beta - gamma.mul(mu).div(denom)
-                A = gamma.div(denom)
-                bias *= A
-                A = A.expand_as(W.transpose(0, -1)).transpose(0, -1)
+                b_BN = beta - gamma.mul(mu).div(denom)
+                W_BN = gamma.div(denom)
+                bias *= W_BN
+                W_BN = W_BN.expand_as(W.transpose(0, -1)).transpose(0, -1)
 
-                W.mul_(A)
-                bias.add_(b)
+                W.mul_(W_BN)
+                if isinstance(stack[-1], nn.ConvTranspose2d):
+                    W = W.transpose(0, 1)
+
+                bias.add_(b_BN)
 
                 stack[-1].weight.data.copy_(W)
                 if stack[-1].bias is None:
                     stack[-1].bias = torch.nn.Parameter(bias)
                 else:
                     stack[-1].bias.data.copy_(bias)
-
         else:
             stack.append(m)
 


### PR DESCRIPTION
Weights in the `Conv2d` layer are stored as tensors with shape `(out_channels, in_channels, kernel_size[0], kernel_size[1])`, while weights in the `ConvTranspose2d` are stored as tensors with shape `(in_channels, out_channels, kernel_size[0], kernel_size[1])`.